### PR TITLE
Fix for IPv6 detection on key wg.endpoint.address

### DIFF
--- a/etc/zabbix/zabbix_agentd.d/wireguard.conf
+++ b/etc/zabbix/zabbix_agentd.d/wireguard.conf
@@ -3,7 +3,7 @@ UserParameter=wg.port.used[*],sudo /usr/bin/wg show $1 listen-port
 UserParameter=wg.fw.mark[*],sudo /usr/bin/wg show $1 fwmark
 UserParameter=wg.peers.count[*],sudo /usr/bin/wg show $1 peers | wc -l 
 UserParameter=wg.peers.connected[*],sudo /usr/bin/wg show $1 endpoints |grep -v "(none)" | wc -l
-UserParameter=wg.endpoint.address[*],sudo /usr/bin/wg show all endpoints |grep -i $1 |awk -F'=' '{print $$2}' |awk -F':' '{print $$1}' | sed -e s'/\t//g'
+UserParameter=wg.endpoint.address[*],sudo /usr/bin/wg show all endpoints |grep -i $1 |awk -F'=' '{print $$2}' | sed -r 's/(.*):.*/\1/g' | sed -e 's/\[//g' | sed -e 's/\]//g' | sed -e s'/\t//g'
 UserParameter=wg.endpoint.port[*],sudo /usr/bin/wg show all endpoints |grep -i $1 |awk -F':' '{print $$2}'
 UserParameter=wg.endpoint.handshake[*],sudo /usr/bin/wg show all latest-handshakes |grep -i $1 | awk '{print $$3}'
 UserParameter=wg.endpoint.allowedips[*],sudo /usr/bin/wg show all allowed-ips |grep -i $1 | cut -f3-


### PR DESCRIPTION
The previous code splitted the ipaddress at the first colon. As IPv6 addresses contains many colons, it should be splitted at the last colon. The new code also removes the quare brackets from ipv6 address.
It detects now IPv4 and IPv6 correctly.

Before:
root@test:/var/lib/zabbix# zabbix_get -s 192.168.170.2 -p 10050 -k wg.endpoint.address[iwufh87ffr]
[2a01

After:
root@test:/var/lib/zabbix# zabbix_get -s 192.168.170.2 -p 10050 -k wg.endpoint.address[iwufh87ffr]
2a01:4f9:2b:1630:beef:1:0:7a64

