### PR TITLE
Preventing use of a separate script for discovery

### DIFF
--- a/etc/zabbix/zabbix_agentd.d/wireguard.conf
+++ b/etc/zabbix/zabbix_agentd.d/wireguard.conf
@@ -1,4 +1,4 @@
-UserParameter=wg.list.discovery[*],sudo /etc/zabbix/zabbix_agentd.d/wireguard $1
+UserParameter=wg.list.discovery[INTERFACES],sudo /usr/bin/wg show interfaces | sed -e '$ ! s/\(.*\)/{"{#WGINTERFACE}":"\1"},/' | sed -e '$  s/\(.*\)/{"{#WGINTERFACE}":"\1"}]/' | sed -e '1  s/\(.*\)/[\1/'
 UserParameter=wg.port.used[*],sudo /usr/bin/wg show $1 listen-port
 UserParameter=wg.fw.mark[*],sudo /usr/bin/wg show $1 fwmark
 UserParameter=wg.peers.count[*],sudo /usr/bin/wg show $1 peers | wc -l 


### PR DESCRIPTION
Added a one-liner bit of code to output the JSON format required to discover interfaces